### PR TITLE
Fix link of ethereum account address to account management page

### DIFF
--- a/src/components/organisms/ConnectionInfo.jsx
+++ b/src/components/organisms/ConnectionInfo.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Link from "redux-first-router-link";
 import displayNumber from "../../utils/displayNumber";
 
 const shortenAddress = address =>
@@ -23,6 +24,7 @@ export const ConnectionInfoComponent = ({
   ethBalance,
   statusMessage,
   statusType,
+  myAccount,
 }) => (
   <div
     style={{
@@ -35,7 +37,8 @@ export const ConnectionInfoComponent = ({
       padding: 5,
     }}
   >
-    <a href="/#/myaccount">{shortenAddress(account || "")}</a> |{" "}
+    <Link to={myAccount()}>{shortenAddress(account || "")}</Link>
+    |{" "}
     <a href={`https://faucet.melon.network/${account}`} target="_blank">
       Ⓜ {displayNumber(mlnBalance)} | Ξ {displayNumber(ethBalance)}
     </a>{" "}

--- a/src/components/pages/App.jsx
+++ b/src/components/pages/App.jsx
@@ -44,6 +44,7 @@ const getMainComponent = ({
   usersFund,
   walletAddress,
   route,
+  myAccount,
 }) => {
   if (route === types.SETUP) {
     const Main = mapOnboardingStateToMainContainer[onboardingState];
@@ -54,6 +55,7 @@ const getMainComponent = ({
         setup
         usersFund={usersFund}
         walletAddress={walletAddress}
+        myAccount={myAccount}
       />
     ) : null;
   }
@@ -69,6 +71,7 @@ const App = props => (
       ethBalance={props.ethBalance}
       statusType={props.statusType}
       statusMessage={props.statusMessage}
+      myAccount={props.myAccount}
     />
     <Container>
       <div className="App-header" style={{ margin: "2em" }}>

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -2,6 +2,7 @@ import BigNumber from "bignumber.js";
 import { connect } from "react-redux";
 import App from "../components/pages/App";
 import { statusTypes } from "../components/organisms/ConnectionInfo";
+import { actions as routeActions } from "../actions/routes";
 
 const getStatus = ({
   syncing,
@@ -47,6 +48,10 @@ const mapStateToProps = state => {
   };
 };
 
-const AppContainer = connect(mapStateToProps)(App);
+const mapDispatchToProps = dispatch => ({
+  myAccount: () => routeActions.myAccount(),
+});
+
+const AppContainer = connect(mapStateToProps, mapDispatchToProps)(App);
 
 export default AppContainer;


### PR DESCRIPTION
Please describe the purpose of this pull request below.
The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)

Copy/paste from CHANGELOG.md is good

### Added

### Changed

### Deprecated

### Removed

### Fixed
- Removed href from account management link

### Security
